### PR TITLE
[ENH] Refactor of bash syntax

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -25,7 +25,6 @@ module load gcc-8.2.0-gcc-4.8.5-sxbf4jq
 module load singularity-3
 module load git-2.29.0-gcc-8.2.0-wb3ybgg
 module load slurm
-. /home/applications/spack/applications/gcc-8.2.0/miniconda3-4.5.11-oqs2mbgv3mmo3dll2f2rbxt4plfgyqzv/etc/profile.d/conda.sh
 
 # Permissions
 umask 0002

--- a/.bash_profile
+++ b/.bash_profile
@@ -1,25 +1,43 @@
+# Notes on .bash* files:
+#
+# .bash_profile - loaded in interactive/login shells,
+#    add commands here that should only be executed once
+#    e.g. module loads, PATH updates.
+#
+# .bashrc - loaded for non-interactive/subshells,
+#    add commands to be done for each new shell
+#    e.g. aliases, customizations, functions.
+#    These are made available to login shell via
+#    "source ~/.bashrc".
+#
+# .custom_env - non-standard madlab environmental file,
+#    used to hold user-specified aliases, functions,
+#    etc. (which are typically held in .bashrc) since
+#    .bashrc is controlled by fiumadlab/madlab_env.git
+
+# Initialize modules for sh shells
 if [[ -f /home/share/Modules/global/profile.modules ]]; then
         . /home/share/Modules/global/profile.modules
 fi
-# put your own module loads here
+
+# Load relevant modules, miniconda
 module load gcc-8.2.0-gcc-4.8.5-sxbf4jq
 module load singularity-3
 module load git-2.29.0-gcc-8.2.0-wb3ybgg
 module load slurm
-
-
-# Get the aliases and functions
-if [ -f ~/.bashrc ]; then
-        . ~/.bashrc
-fi
-
-# User specific environment and startup programs
+. /home/applications/spack/applications/gcc-8.2.0/miniconda3-4.5.11-oqs2mbgv3mmo3dll2f2rbxt4plfgyqzv/etc/profile.d/conda.sh
 
 # Permissions
 umask 0002
 umask g+w
 
-PATH=$PATH:$HOME/bin
-PYTHONPATH="${PYTHONPATH}:/home/data/madlab/scripts"
-export PATH
-export PYTHONPATH
+# User specific environment and startup programs
+# PATH=$PATH:$HOME/bin
+# export PATH
+# PYTHONPATH="${PYTHONPATH}:/home/data/madlab/scripts"
+# export PYTHONPATH
+
+# Make aliases and customizations available.
+if [ -f ~/.bashrc ]; then
+        source ~/.bashrc
+fi

--- a/.bashrc
+++ b/.bashrc
@@ -1,33 +1,56 @@
+# Notes on .bash* files:
+#
+# .bash_profile - loaded in interactive/login shells,
+#    add commands here that should only be executed once
+#    e.g. module loads, PATH updates.
+#
+# .bashrc - loaded for non-interactive/subshells,
+#    add commands to be done for each new shell
+#    e.g. aliases, customizations, functions.
+#    These are made available to login shell via
+#    "source ~/.bashrc".
+#
+# .custom_env - non-standard madlab environmental file,
+#    used to hold user-specified aliases, functions,
+#    etc. (which are typically held in .bashrc) since
+#    .bashrc is controlled by fiumadlab/madlab_env.git
+
+# Initialize module for sh shells
 case "$0" in
-          -sh|sh|*/sh)
-modules_shell=sh ;;
-       -ksh|ksh|*/ksh)
-modules_shell=ksh ;;
-       -zsh|zsh|*/zsh)
-modules_shell=zsh ;;
-    -bash|bash|*/bash)
-modules_shell=bash ;;
+       -sh|sh|*/sh) modules_shell=sh
+              ;;
+       -ksh|ksh|*/ksh) modules_shell=ksh
+              ;;
+       -zsh|zsh|*/zsh) modules_shell=zsh
+              ;;
+       -bash|bash|*/bash) modules_shell=bash
+              ;;
+       *) echo "Setting sh as default shell" >&1
+              modules_shell=sh
+              ;;
 esac
-module() { eval `/home/share/Modules/default/bin/modulecmd $modules_shell $*`; }
+module() {
+       eval `/home/share/Modules/default/bin/modulecmd $modules_shell $*`
+}
 
 # Source global definitions
 if [ -f /etc/bashrc ]; then
-. /etc/bashrc
+       source /etc/bashrc
+fi
+
+# Get user customizations
+if [ -f ~/.custom_env ]; then
+       source ~/.custom_env
 fi
 
 # Project-specific environments
 source ~/.projects
 
-# Permissions
-umask 0002
-umask g+w
-
 # User specific aliases and functions
 alias ls="ls --color=auto"
+
 # Setup a fancy shell command prompt:
 prompt1="\[\e[0;33m\][\A]\[\e[0m\]" # Display the time in the bash prompt
 prompt2="\[\e[1;39m\]\u@\h:\W\$\[\e[0m\]" # Add username@host:dir$
 promptinfo=`${HOME}/.nodeload`
 PROMPT_COMMAND='PS1="\[\e[1;37m\e[44m\]${project_name}\[\e[0;0m\]${prompt1}${promptinfo}${prompt2}"'
-
-. /home/applications/spack/applications/gcc-8.2.0/miniconda3-4.5.11-oqs2mbgv3mmo3dll2f2rbxt4plfgyqzv/etc/profile.d/conda.sh

--- a/.bashrc
+++ b/.bashrc
@@ -38,6 +38,8 @@ if [ -f /etc/bashrc ]; then
        source /etc/bashrc
 fi
 
+. /home/applications/spack/applications/gcc-8.2.0/miniconda3-4.5.11-oqs2mbgv3mmo3dll2f2rbxt4plfgyqzv/etc/profile.d/conda.sh
+
 # Get user customizations
 if [ -f ~/.custom_env ]; then
        source ~/.custom_env

--- a/.bashrc
+++ b/.bashrc
@@ -25,8 +25,7 @@ case "$0" in
               ;;
        -bash|bash|*/bash) modules_shell=bash
               ;;
-       *) echo "Setting sh as default shell" >&1
-              modules_shell=sh
+       *) modules_shell=sh
               ;;
 esac
 module() {

--- a/.nodeload
+++ b/.nodeload
@@ -8,21 +8,18 @@ nodemem=`free | grep Mem`
 nodememtotal=`echo ${nodemem} | awk '{print $2}'`
 nodememused=$((`echo ${nodemem} | awk '{print $3}'`))
 nodemem=$((99*${nodememused}/${nodememtotal}))
-if [ $nodeloadint -ge $((100*${numcpus}/5*4/100)) ]
-then
+
+if [ $nodeloadint -ge $((100*${numcpus}/5*4/100)) ]; then
         echo -en "\[\e[1;31m\][$nodeload]\[\e[0m\]"
-elif [ $nodeloadint -ge $((100*${numcpus}/2*1/100)) ]
-then
+elif [ $nodeloadint -ge $((100*${numcpus}/2*1/100)) ]; then
         echo -en "\[\e[1;33m\][$nodeload]\[\e[0m\]"
 else
         echo -en "\[\e[1;32m\][$nodeload]\[\e[0m\]"
 fi
 
-if [ $nodemem -ge 80 ]
-then
+if [ $nodemem -ge 80 ]; then
         echo -en "\[\e[1;31m\][$nodemem%]\[\e[0m\]"
-elif [ $nodemem -ge 50 ]
-then
+elif [ $nodemem -ge 50 ]; then
         echo -en "\[\e[1;33m\][$nodemem%]\[\e[0m\]"
 else
         echo -en "\[\e[1;32m\][$nodemem%]\[\e[0m\]"

--- a/clean_files.sh
+++ b/clean_files.sh
@@ -1,2 +1,2 @@
-#! /bin/bash
-rm ~/.bashrc ~/.bash_profile ~/.nodeload ~/.projects
+#!/bin/bash
+rm ~/.{bashrc,bash_profile,nodeload,projects}


### PR DESCRIPTION
Light updates to organization, comments, and content in bash files. Made .bash_profile reference login commands, .bashrc reference other commands and configurations.

.bash_profile
- added description and usage
- general formatting and reorganization - kept single login commands, moved non-interactive/subshell commands to .bashrc

.bashrc
- added description and usage
- general formatting and reorganization - kept only non-interactive/susbshell commands
- added source of .custom_env
- added catch to case

clean_files.sh
- moved to brace expansion

.nodeload
- reformatted